### PR TITLE
Fix secondary title render issue with markdown-it on cookie policy and privacy policy page.

### DIFF
--- a/src/app/info/cookie-policy/cookie-policy.md
+++ b/src/app/info/cookie-policy/cookie-policy.md
@@ -1,4 +1,5 @@
-﻿## Updated August 2023
+﻿
+## Updated August 2023
 
 Website: [wwwnow-u.com](https://now-u.com)
 

--- a/src/app/info/privacy-notice/privacy-notice.md
+++ b/src/app/info/privacy-notice/privacy-notice.md
@@ -1,4 +1,5 @@
-﻿## 1. Who we are
+﻿
+## 1. Who we are
 
 Welcome to the Privacy Notice of now-u, a community interest company (“CIC”) incorporated in England and Wales (Registration Number 12709184).
 


### PR DESCRIPTION
Fix #31 

Previously the cookie policy and privacy notice page doesn't render first title appeared in the .md file properly. This might be related to how markdown-it renders a .md file internally. Because spaces are usually quite important for markdown rendering engines, I add a newline at the top of these two .md files and now it renders just fine.

Please review @JElgar 