### PR TITLE
Use Revalidation for Fetch

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -8,6 +8,10 @@ export type BlogPost = components["schemas"]["Blog"];
 
 export const apiClient = createClient<paths>({
   baseUrl: "https://causes.dev.apiv2.now-u.com",
+  fetch: fetch,
+  next: {
+    revalidate: 60
+  }
 });
 
 export async function getCauses(): Promise<Cause[]> {


### PR DESCRIPTION
Close #53

This PR try to use auto revalidation (revalidate after maximum 60s), but I need backend developer to help me check whether the automatic revalidation is working (use vercel preview link should work). Try update content in one of the article and then wait for at most 60s, the content should be refreshed. If not, we probably have to use `{ cache: "no-store" }` for now, please let me know about this. 
