### PR TITLE
Make it always make new request (no cache)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,11 @@ const withRoutes = require("nextjs-routes/config")();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
   images: {
     remotePatterns: [
       {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -9,9 +9,7 @@ export type BlogPost = components["schemas"]["Blog"];
 export const apiClient = createClient<paths>({
   baseUrl: "https://causes.dev.apiv2.now-u.com",
   fetch: fetch,
-  next: {
-    revalidate: 60
-  }
+  cache: "no-store"
 });
 
 export async function getCauses(): Promise<Cause[]> {


### PR DESCRIPTION
Close #53. Because PR #54 doesn't work as expected, we now publish a new update to always fetch from api (no cache at all).

Also added logging for request in dev mode to check if it's using cache.